### PR TITLE
Add web app to fetch Sonarr missing anime episodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # Anime
-App to monitor active anime downloads
+
+Simple Flask app to monitor missing anime episodes in Sonarr against the Animetosho RSS feed.
+
+## Setup
+
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Provide your Sonarr API key and optional URL via environment variables:
+   ```bash
+   export SONARR_API_KEY="yourkey"
+   export SONARR_URL="https://sonarr.manxrallying.uk/api/v3"  # optional
+   ```
+3. Run the app
+   ```bash
+   python app.py
+   ```
+
+Open `http://localhost:5000/` to view NZB links for missing episodes.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,60 @@
+import os
+import re
+from flask import Flask, jsonify
+import requests
+import feedparser
+
+SONARR_URL = os.environ.get("SONARR_URL", "https://sonarr.manxrallying.uk/api/v3")
+SONARR_API_KEY = os.environ.get("SONARR_API_KEY")
+FEED_URL = "https://feed.animetosho.org/rss2"
+
+app = Flask(__name__)
+
+def get_missing_episodes():
+    headers = {"X-Api-Key": SONARR_API_KEY} if SONARR_API_KEY else {}
+    try:
+        resp = requests.get(
+            f"{SONARR_URL}/wanted/missing",
+            params={"includeSeries": "true", "pageSize": 1000},
+            headers=headers,
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        episodes = data.get("records", [])
+        missing = []
+        for ep in episodes:
+            series_title = ep["series"]["title"]
+            ep_num = ep["episodeNumber"]
+            missing.append({"series": series_title, "episode": ep_num})
+        return missing
+    except Exception:
+        return []
+
+def parse_feed():
+    feed = feedparser.parse(FEED_URL)
+    entries = []
+    pattern = re.compile(r"^(.*?) - (\d+)")
+    for e in feed.entries:
+        match = pattern.match(e.title)
+        if not match:
+            continue
+        series_title = match.group(1)
+        episode = int(match.group(2))
+        link = e.enclosures[0]["url"] if e.get("enclosures") else e.link
+        entries.append({"series": series_title, "episode": episode, "link": link})
+    return entries
+
+@app.route("/")
+def index():
+    missing = get_missing_episodes()
+    feed_entries = parse_feed()
+    available = []
+    for m in missing:
+        for f in feed_entries:
+            if f["series"].lower() == m["series"].lower() and f["episode"] == m["episode"]:
+                available.append({"series": m["series"], "episode": m["episode"], "link": f["link"]})
+    return jsonify(available)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+feedparser
+requests


### PR DESCRIPTION
## Summary
- build Flask app that cross-checks Sonarr's missing episodes with Animetosho RSS feed
- document setup and dependencies
- add gitignore for Python artifacts

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_689e0bb1f6b08320a04ead2715670338