### PR TITLE
Log Sonarr API request failures

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,8 @@ def get_missing_episodes():
             ep_num = ep["episodeNumber"]
             missing.append({"series": series_title, "episode": ep_num})
         return missing
-    except Exception:
+    except Exception as e:
+        app.logger.error(f"Sonarr request failed: {e}")
         return []
 
 def parse_feed():


### PR DESCRIPTION
## Summary
- log Sonarr request errors in `get_missing_episodes`

## Testing
- `pytest -q`
- `SONARR_URL=http://localhost:9 python app.py` & `curl -s http://127.0.0.1:5000/`


------
https://chatgpt.com/codex/tasks/task_e_689e23120e5c8320bfe3886abcde0040