### PR TITLE
Initialize minimal Sonarr missing episodes viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,19 @@
-# Anime
+# Anime Missing Episodes Viewer
 
-Simple Flask app to monitor missing anime episodes in Sonarr against the Animetosho RSS feed.
+A simple Flask web page that lists series with missing episodes from a Sonarr instance.
 
-## Setup
+## Configuration
 
-1. Install dependencies
-   ```bash
-   pip install -r requirements.txt
-   ```
-2. Provide your Sonarr API key and optional URL via environment variables:
-   - **Windows PowerShell**
-     ```powershell
-     $env:SONARR_API_KEY='88072cfcffd64b9fb09967534795d361'
-     $env:SONARR_URL='https://sonarr.manxrallying.uk/api/v3'  # optional
-     # persist for future sessions
-     setx SONARR_API_KEY '88072cfcffd64b9fb09967534795d361'
-     setx SONARR_URL 'https://sonarr.manxrallying.uk/api/v3'
-     ```
-=======
-   ```bash
-   export SONARR_API_KEY="yourkey"
-   export SONARR_URL="https://sonarr.manxrallying.uk/api/v3"  # optional
-   ```
-main
-3. Run the app
-   ```bash
-   python app.py
-   ```
+The app uses the following environment variables:
 
-Open `http://localhost:5000/` to view NZB links for missing episodes.
+- `SONARR_URL` – Base URL of the Sonarr instance. Defaults to `https://sonarr.manxrallying.uk`.
+- `SONARR_API_KEY` – API key for Sonarr. Defaults to `88072cfcffd64b9fb09967534795d361`.
+
+## Running
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Visit `http://localhost:5000/` to view the list of series with missing episodes.

--- a/app.py
+++ b/app.py
@@ -1,63 +1,28 @@
 import os
-import re
-from flask import Flask, jsonify
+from flask import Flask, render_template
 import requests
-import feedparser
-
-SONARR_URL = os.environ.get("SONARR_URL", "https://sonarr.manxrallying.uk/api/v3")
-SONARR_API_KEY = os.environ.get(
-    "SONARR_API_KEY", "88072cfcffd64b9fb09967534795d361"
-)
-FEED_URL = "https://feed.animetosho.org/rss2"
 
 app = Flask(__name__)
 
-def get_missing_episodes():
-    headers = {"X-Api-Key": SONARR_API_KEY} if SONARR_API_KEY else {}
-    try:
-        resp = requests.get(
-            f"{SONARR_URL}/wanted/missing",
-            params={"includeSeries": "true", "pageSize": 1000},
-            headers=headers,
-            timeout=10,
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        episodes = data.get("records", [])
-        missing = []
-        for ep in episodes:
-            series_title = ep["series"]["title"]
-            ep_num = ep["episodeNumber"]
-            missing.append({"series": series_title, "episode": ep_num})
-        return missing
-    except Exception as e:
-        app.logger.error(f"Sonarr request failed: {e}")
-        return []
-
-def parse_feed():
-    feed = feedparser.parse(FEED_URL)
-    entries = []
-    pattern = re.compile(r"^(.*?) - (\d+)")
-    for e in feed.entries:
-        match = pattern.match(e.title)
-        if not match:
-            continue
-        series_title = match.group(1)
-        episode = int(match.group(2))
-        link = e.enclosures[0]["url"] if e.get("enclosures") else e.link
-        entries.append({"series": series_title, "episode": episode, "link": link})
-    return entries
+API_KEY = os.getenv("SONARR_API_KEY", "88072cfcffd64b9fb09967534795d361")
+SONARR_URL = os.getenv("SONARR_URL", "https://sonarr.manxrallying.uk")
 
 @app.route("/")
 def index():
-    missing = get_missing_episodes()
-    feed_entries = parse_feed()
-    available = []
-    for m in missing:
-        for f in feed_entries:
-            if f["series"].lower() == m["series"].lower() and f["episode"] == m["episode"]:
-                available.append({"series": m["series"], "episode": m["episode"], "link": f["link"]})
-    return jsonify(available)
+    url = f"{SONARR_URL}/api/v3/wanted/missing?includeSeries=true"
+    try:
+        resp = requests.get(url, headers={"X-Api-Key": API_KEY})
+        resp.raise_for_status()
+        data = resp.json()
+        series = {}
+        for item in data.get("records", []):
+            s = item.get("series")
+            if s:
+                series[s["id"]] = s["title"]
+        series_list = sorted(series.values())
+    except Exception as e:
+        series_list = [f"Error fetching data: {e}"]
+    return render_template("index.html", series=series_list)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Flask
-feedparser
 requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Missing Series</title>
+</head>
+<body>
+    <h1>Series with Missing Episodes</h1>
+    <ul>
+    {% for name in series %}
+        <li>{{ name }}</li>
+    {% else %}
+        <li>No missing episodes found.</li>
+    {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove old app scaffold
- add Flask app that lists series with missing Sonarr episodes
- document configuration and usage

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689e26acb98c832091ac0a9fc5bfdf23